### PR TITLE
Spike: searching podcasts using podcastindex api

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -20,6 +20,10 @@ if System.get_env("PHX_SERVER") do
   config :publisher_backend, Publisher.BackendWeb.Endpoint, server: true
 end
 
+config :publisher_backend, Publisher.Backend.PodcastSearch,
+  key: System.get_env("PODCASTINDEX_KEY"),
+  secret: System.get_env("PODCASTINDEX_SECRET")
+
 if config_env() == :prod do
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/server/lib/publisher_backend/podcast_search.ex
+++ b/server/lib/publisher_backend/podcast_search.ex
@@ -1,0 +1,35 @@
+defmodule Publisher.Backend.PodcastSearch do
+  def search(value) do
+    config = Application.get_env(:publisher_backend, __MODULE__)
+    key = Keyword.get(config, :key)
+    secret = Keyword.get(config, :secret)
+    time = DateTime.utc_now() |> DateTime.to_unix()
+
+    hash =
+      :crypto.hash(:sha, key <> secret <> to_string(time))
+      |> Base.encode16()
+      |> String.downcase()
+
+    req = Req.new(base_url: "https://api.podcastindex.org/api/1.0")
+
+    req =
+      Req.Request.put_headers(req, [
+        {"User-Agent", "Podlove/OnboardingWizard"},
+        {"X-Auth-Key", key},
+        {"X-Auth-Date", to_string(time)},
+        {"Authorization", hash}
+      ])
+
+    result =
+      Req.get!(
+        req,
+        url: "/search/byterm",
+        params: %{q: value}
+      )
+
+    result.body["feeds"]
+    |> Enum.map(fn feed ->
+      Map.take(feed, ["title", "url", "image", "author"])
+    end)
+  end
+end


### PR DESCRIPTION
Sucht Podcasts nach Namen, damit wir über ein Suchfeld den RSS Feed ermitteln können.

Erfordert Umgebungsvariablen `PODCASTINDEX_KEY` und `PODCASTINDEX_SECRET`. Siehe https://podcastindex-org.github.io/docs-api/#overview--authentication-details

```elixir
iex(1)> Publisher.Backend.PodcastSearch.search("podlovers")    
[
  %{
    "author" => "Podlovers",
    "image" => "http://backend.podlovers.org/wp-content/uploads/2020/07/white-green_3000x3000.png",
    "title" => "Podlovers",
    "url" => "https://feeds.podlovers.org/mp3"
  },
  %{
    "author" => "Norman Chella",
    "image" => "https://storage.buzzsprout.com/variants/t4x1soo2cswcss9bf47wu8x5y7kr/60854458c4d1acdf4e1c2f79c4137142d85d78e379bdafbd69bd34c85f5819ad.jpg",
    "title" => "Podlovers Asia: All about Asian Podcasting",
    "url" => "https://feeds.buzzsprout.com/1362508.rss"
  },
  %{
    "author" => "Podlove",
    "image" => "https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo/13442246/13442246-1615335081254-952ca5936395d.jpg",
    "title" => "Podlove",
    "url" => "https://anchor.fm/s/50b7d3d8/podcast/rss"
  },
  %{
    "author" => "Lovi Dinar",
    "image" => "https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded/3678515/3678515-1585272391231-f33fdd0b0a194.jpg",
    "title" => "PodLov",
    "url" => "https://anchor.fm/s/16858e6c/podcast/rss"
  }
]
```