### PR TITLE
Feature: guid

### DIFF
--- a/server/lib/publisher/feed_parser.ex
+++ b/server/lib/publisher/feed_parser.ex
@@ -16,6 +16,7 @@ defmodule Publisher.FeedParser do
     {:ok,
      %{
        podcast: %{
+         guid: feed.guid,
          title: feed.title,
          description: feed.description,
          image: feed.image_url,

--- a/server/mix.lock
+++ b/server/mix.lock
@@ -12,7 +12,7 @@
   "hpax": {:hex, :hpax, "0.1.2", "09a75600d9d8bbd064cdd741f21fc06fc1f4cf3d0fcc335e5aa19be1a7235c84", [:mix], [], "hexpm", "2c87843d5a23f5f16748ebe77969880e29809580efdaccd615cd3bed628a8c13"},
   "idna": {:hex, :idna, "6.1.1", "8a63070e9f7d0c62eb9d9fcb360a7de382448200fbbd1b106cc96d3d8099df8d", [:rebar3], [{:unicode_util_compat, "~> 0.7.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm", "92376eb7894412ed19ac475e4a86f7b413c1b9fbb5bd16dccd57934157944cea"},
   "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
-  "metalove": {:git, "https://github.com/podlove/metalove", "00538e2d763172448b0fdf11d6e0d6bb6eb5c54a", [branch: "master"]},
+  "metalove": {:git, "https://github.com/podlove/metalove", "6678fb8084771d039ea6430a03e6f822bd35667e", [branch: "master"]},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "2.0.5", "dc34c8efd439abe6ae0343edbb8556f4d63f178594894720607772a041b04b02", [:mix], [], "hexpm", "da0d64a365c45bc9935cc5c8a7fc5e49a0e0f9932a761c55d6c52b142780a05c"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},

--- a/server/test/data/podlovers.xml
+++ b/server/test/data/podlovers.xml
@@ -3,6 +3,7 @@
 	xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:psc="http://podlove.org/simple-chapters" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:fh="http://purl.org/syndication/history/1.0" xmlns:podcast="https://podcastindex.org/namespace/1.0" >
 
 <channel>
+	<podcast:guid>88e824bf-54bb-498f-8b6f-e0327ade3e87</podcast:guid>
 	<title>Podlovers</title>
 	<link>https://podlovers.org/</link>
 	<description><![CDATA[Der Podlove Entwickler:innen Podcast]]></description>

--- a/server/test/publisher_test.exs
+++ b/server/test/publisher_test.exs
@@ -18,6 +18,7 @@ defmodule PublisherTest do
     assert result.podcast.image == "http://example.com/image.png"
     assert result.podcast.owner == %{name: "Podlovers", email: "feed@podlovers.org"}
     assert result.podcast.explicit == false
+    assert result.podcast.guid == "88e824bf-54bb-498f-8b6f-e0327ade3e87"
 
     assert result.podcast.categories == [
              ["Technology"],


### PR DESCRIPTION
Feed parser extracts and returns the podcast guid.

Needs https://github.com/podlove/podlove-publisher/pull/1471, then we can write it during import.