### PR TITLE
chore: Copy image validator - name alignment

### DIFF
--- a/server/lib/publisher_web/controllers/api.ex
+++ b/server/lib/publisher_web/controllers/api.ex
@@ -54,7 +54,7 @@ defmodule PublisherWeb.Controllers.API do
 
   def copy_podcast_image(conn, headers, body) do
     with_validation(conn, headers_to_map(headers), Validator.WordPressAuthHeaders, fn conn, _ ->
-      with_validation(conn, body, Validator.MovePodcastImage, fn conn, body_data ->
+      with_validation(conn, body, Validator.CopyPodcastImage, fn conn, body_data ->
         case Podcast.copy_podcast_image(headers, body_data) do
           {:ok, info} -> json(conn, info)
           {:error, reason} -> send_resp(conn, 400, "Error: #{reason}")

--- a/server/lib/publisher_web/controllers/validator/copy_podcast_image.ex
+++ b/server/lib/publisher_web/controllers/validator/copy_podcast_image.ex
@@ -1,4 +1,4 @@
-defmodule PublisherWeb.Controllers.Validator.MovePodcastImage do
+defmodule PublisherWeb.Controllers.Validator.CopyPodcastImage do
   use PublisherWeb.Controllers.Validator.Validator
 
   embedded_schema do


### PR DESCRIPTION
Ich habe den Namen des Validators für das Übertragen eines Bilds von einer URL zu Wordpress angepasst. 