### PR TITLE
fix(server) - upload media handling http error

### DIFF
--- a/server/lib/publisher/wordpress/api.ex
+++ b/server/lib/publisher/wordpress/api.ex
@@ -4,35 +4,31 @@ defmodule Publisher.WordPress.API do
 
   ## Example
 
-    req = API.new(headers, http1)
+    req = API.new(headers)
     {:ok, response} = Req.get(req, url: "podlove/v2/episodes")
 
   """
-  def new(headers, http1) do
+  def new(headers, opts \\ []) do
     user = get_header_value(headers, "wordpress-user")
     password = get_header_value(headers, "wordpress-password")
     site = get_header_value(headers, "wordpress-site")
 
-    if (http1) do
-      Req.new(
-        base_url: site <> "/wp-json/",
-        headers: [{"Content-Type", "application/json"}],
-        auth: {:basic, user <> ":" <> password},
-        connect_options: [
-          transport_opts: [verify: :verify_none]
-        ]
-      )
-    else
-      Req.new(
-        base_url: site <> "/wp-json/",
-        headers: [{"Content-Type", "application/json"}],
-        auth: {:basic, user <> ":" <> password},
-        connect_options: [
-          protocols: [:http1],
-          transport_opts: [verify: :verify_none]
-        ]
-      )
+    default_connect_options = [transport_opts: [verify: :verify_none]]
+    http1 = Keyword.get(opts, :http1, false)
+
+    connect_options =
+      if http1 do
+        Keyword.put(default_connect_options, :protocols, [:http1])
+      else
+        default_connect_options
       end
+
+    Req.new(
+      base_url: site <> "/wp-json/",
+      headers: [{"Content-Type", "application/json"}],
+      auth: {:basic, user <> ":" <> password},
+      connect_options: connect_options
+    )
   end
 
   defp get_header_value(headers, header_item) do

--- a/server/lib/publisher/wordpress/episode.ex
+++ b/server/lib/publisher/wordpress/episode.ex
@@ -5,7 +5,7 @@ defmodule Publisher.WordPress.Episode do
   alias Publisher.WordPress.Media
 
   def save(conn, params) do
-    req = API.new(conn.req_headers, true)
+    req = API.new(conn.req_headers, http1: true)
 
     with episode_id <- find_or_create_episode(req, params["guid"]),
          post_id <- fetch_post_id(req, episode_id),

--- a/server/lib/publisher/wordpress/podcast.ex
+++ b/server/lib/publisher/wordpress/podcast.ex
@@ -32,7 +32,7 @@ defmodule Publisher.WordPress.Podcast do
       |> reject_empty_values()
       |> Enum.into(%{})
 
-    req = API.new(headers, false)
+    req = API.new(headers)
 
     with {:ok, response} <- Req.post(req, url: "podlove/v2/onboarding/setup", json: payload),
          {:ok, _} <- extract_status(response) do
@@ -58,7 +58,7 @@ defmodule Publisher.WordPress.Podcast do
       explicit: body.explicit
     }
 
-    req = API.new(headers, false)
+    req = API.new(headers)
 
     with {:ok, response} <- Req.post(req, url: "podlove/v2/podcast", json: payload),
          {:ok, _} <- extract_status(response) do
@@ -76,7 +76,7 @@ defmodule Publisher.WordPress.Podcast do
     # Logger.log(:info, "user: #{user}, endpoint: #{site}/wp-json/wp/v2/media")
     Logger.log(:info, "body { name: #{image_name}, type: #{image_type} }")
 
-    req = API.new(headers, true)
+    req = API.new(headers, http1: true)
 
     with {:ok, source_url} <- Media.upload_image(req, base64_image, image_name, image_type),
          {:ok, info} <- save_podcast_image_url(req, source_url) do
@@ -93,7 +93,7 @@ defmodule Publisher.WordPress.Podcast do
     # Logger.log(:info, "user: #{user}, endpoint: #{site}/wp-json/wp/v2/media")
     Logger.log(:info, "body { name: #{image_name}, url: #{image_url} }")
 
-    req = API.new(headers, true)
+    req = API.new(headers, http1: true)
 
     with {:ok, source_url} <- Media.upload_media_from_url(req, image_url, image_name),
          {:ok, info} <- save_podcast_image_url(req, source_url) do


### PR DESCRIPTION
Bei großen Uploads kam es zu Mint:Http Fehlern. Ich umgehe das Problem jetzt in dem ich für die Media Uploads vorsorglich das Protokoll auf http1 umstelle. 

